### PR TITLE
fix: update hdf5 filter keys and modify observation modalities in robomimic config

### DIFF
--- a/source/extensions/orbit.surgical.tasks/orbit/surgical/tasks/surgical/lift/config/needle/agents/robomimic/bc.json
+++ b/source/extensions/orbit.surgical.tasks/orbit/surgical/tasks/surgical/lift/config/needle/agents/robomimic/bc.json
@@ -40,7 +40,8 @@
         "hdf5_cache_mode": "all",
         "hdf5_use_swmr": true,
         "hdf5_normalize_obs": false,
-        "hdf5_filter_key": null,
+        "hdf5_filter_key": "train",
+        "hdf5_validation_filter_key": "valid", 
         "seq_length": 1,
         "dataset_keys": [
             "actions",
@@ -141,10 +142,10 @@
         "modalities": {
             "obs": {
                 "low_dim": [
-                    "tool_dof_pos_scaled",
-                    "tool_positions",
-                    "object_relative_tool_positions",
-                    "object_desired_positions"
+                    "joint_pos",
+                    "joint_vel",
+                    "object_position",
+                    "target_object_position"
                 ],
                 "rgb": [],
                 "depth": [],


### PR DESCRIPTION

This pull request  will solve the subsequence issue after fixing #12 to make the romomimic bc training run successfully.

This pull request includes changes to the `source/extensions/orbit.surgical.tasks/orbit/surgical/tasks/surgical/lift/config/needle/agents/robomimic/bc.json` file to update the configuration settings for the Robomimic agent.

Configuration updates:

* Added the `hdf5_filter_key` to "train" and added a new `hdf5_validation_filter_key` set to "valid".
* Updated the `low_dim` modalities by replacing the old keys with new ones: "tool_dof_pos_scaled", "tool_positions", "object_relative_tool_positions", and "object_desired_positions" were replaced with "joint_pos", "joint_vel", "object_position", and "target_object_position".